### PR TITLE
Vsc456 correct number range and functionality

### DIFF
--- a/content/AuxBmsView.qml
+++ b/content/AuxBmsView.qml
@@ -12,6 +12,8 @@ Item {
         y: 39
         width: 119
         height: 37
+        to: 255
+        editable: true
         value: bms.prechargeState
         onValueChanged: bms.setPrechargeState(value)
     }
@@ -30,6 +32,8 @@ Item {
         y: 102
         width: 119
         height: 37
+        to: 255
+        editable: true
         value: bms.auxVoltage
         onValueChanged: bms.setAuxVoltage(value)
     }

--- a/content/BatteryView.qml
+++ b/content/BatteryView.qml
@@ -92,6 +92,8 @@ Item {
         y: 259
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.populatedCells
         onValueChanged: battery.setPopulatedCells(value)
     }
@@ -110,6 +112,9 @@ Item {
         y: 259
         width: 94
         height: 36
+        from: -2147483648
+        to: 2147483647
+        editable: true
         value: battery.input12V
         onValueChanged: battery.setInput12V(value)
     }
@@ -128,6 +133,9 @@ Item {
         y: 259
         width: 94
         height: 36
+        from: -2147483648
+        to: 2147483647
+        editable: true
         value: battery.fanVoltage
         onValueChanged: battery.setFanVoltage(value)
     }
@@ -146,6 +154,9 @@ Item {
         y: 259
         width: 94
         height: 36
+        from: -2147483648
+        to: 2147483647
+        editable: true
         value: battery.packCurrent
         onValueChanged: battery.setPackCurrent(value)
     }
@@ -164,6 +175,9 @@ Item {
         y: 259
         width: 94
         height: 36
+        from: -2147483648
+        to: 2147483647
+        editable: true
         value: battery.packVoltage
         onValueChanged: battery.setPackVoltage(value)
     }
@@ -182,6 +196,9 @@ Item {
         y: 259
         width: 94
         height: 36
+        from: -2147483648
+        to: 2147483647
+        editable: true
         value: battery.packSoc
         onValueChanged: battery.setPackSoc(value)
     }
@@ -200,6 +217,9 @@ Item {
         y: 259
         width: 94
         height: 36
+        from: -2147483648
+        to: 2147483647
+        editable: true
         value: battery.packAmphours
         onValueChanged: battery.setPackAmphours(value)
     }
@@ -218,6 +238,9 @@ Item {
         y: 326
         width: 94
         height: 36
+        from: -2147483648
+        to: 2147483647
+        editable: true
         value: battery.setPackDod
         onValueChanged: battery.setPackDod(value)
     }
@@ -236,6 +259,8 @@ Item {
         y: 326
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.highTemp
         onValueChanged: battery.setHighTemp(value)
     }
@@ -254,6 +279,8 @@ Item {
         y: 326
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.highThermistorId
         onValueChanged: battery.setHighThermistorId(value)
     }
@@ -272,6 +299,8 @@ Item {
         y: 326
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.lowTemp
         onValueChanged: battery.setLowTemp(value)
     }
@@ -290,6 +319,8 @@ Item {
         y: 326
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.lowThermistorId
         onValueChanged: battery.setLowThermistorId(value)
     }
@@ -308,6 +339,8 @@ Item {
         y: 326
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.avgTemp
         onValueChanged: battery.setAvgTemp(value)
     }
@@ -326,6 +359,8 @@ Item {
         y: 326
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.internalTemp
         onValueChanged: battery.setInternalTemp(value)
     }
@@ -344,6 +379,8 @@ Item {
         y: 394
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.fanSpeed
         onValueChanged: battery.setFanSpeed(value)
     }
@@ -362,6 +399,8 @@ Item {
         y: 394
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.reqFanSpeed
         onValueChanged: battery.setReqFanSpeed(value)
     }
@@ -380,6 +419,8 @@ Item {
         y: 394
         width: 94
         height: 36
+        to: 65535
+        editable: true
         value: battery.lowCellVoltage
         onValueChanged: battery.setLowCellVoltage(value)
     }
@@ -398,6 +439,8 @@ Item {
         y: 394
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.lowCellVoltageId
         onValueChanged: battery.setLowCellVoltageId(value)
     }
@@ -416,6 +459,8 @@ Item {
         y: 394
         width: 94
         height: 36
+        to: 65535
+        editable: true
         value: battery.highCellVoltage
         onValueChanged: battery.setHighCellVoltage(value)
     }
@@ -434,6 +479,8 @@ Item {
         y: 394
         width: 94
         height: 36
+        to: 255
+        editable: true
         value: battery.highCellVoltageId
         onValueChanged: battery.setHighCellVoltageId(value)
     }
@@ -452,6 +499,8 @@ Item {
         y: 394
         width: 94
         height: 36
+        to: 65535
+        editable: true
         value: battery.avgCellVoltage
         onValueChanged: battery.setAvgCellVoltage(value)
     }

--- a/content/BatteryView.qml
+++ b/content/BatteryView.qml
@@ -98,6 +98,7 @@ Item {
         onValueChanged: battery.setPopulatedCells(value)
     }
 
+
     Text {
         id: text1
         x: 43
@@ -106,18 +107,18 @@ Item {
         font.pixelSize: 12
     }
 
-    SpinBox {
-        id: spinBox1
-        x: 138
-        y: 259
-        width: 94
-        height: 36
-        from: -2147483648
-        to: 2147483647
-        editable: true
-        value: battery.input12V
-        onValueChanged: battery.setInput12V(value)
+    FloatSpinBox {
+        id: floatSpinBox1
+        x:138
+        y:259
+        width:94
+        height:36
+        value: decimalToInt(battery.input12V)
+        stepSize: decimalToInt(0.5)
+        onValueChanged: battery.setInput12V(value / decimalFactor)
     }
+
+
 
     Text {
         id: text2
@@ -127,17 +128,15 @@ Item {
         font.pixelSize: 12
     }
 
-    SpinBox {
-        id: spinBox2
+    FloatSpinBox {
+        id: floatSpinBox2
         x: 238
         y: 259
         width: 94
         height: 36
-        from: -2147483648
-        to: 2147483647
-        editable: true
-        value: battery.fanVoltage
-        onValueChanged: battery.setFanVoltage(value)
+        value: decimalToInt(battery.fanVoltage)
+        onValueChanged: battery.setFanVoltage(value/decimalFactor)
+        stepSize: decimalToInt(0.5)
     }
 
     Text {
@@ -148,17 +147,15 @@ Item {
         font.pixelSize: 12
     }
 
-    SpinBox {
-        id: spinBox3
+    FloatSpinBox {
+        id: floatSpinBox3
         x: 338
         y: 259
         width: 94
         height: 36
-        from: -2147483648
-        to: 2147483647
-        editable: true
-        value: battery.packCurrent
-        onValueChanged: battery.setPackCurrent(value)
+        value: decimalToInt(battery.packCurrent)
+        onValueChanged: battery.setPackCurrent(value/decimalFactor)
+        stepSize: decimalToInt(0.5)
     }
 
     Text {
@@ -169,17 +166,16 @@ Item {
         font.pixelSize: 12
     }
 
-    SpinBox {
-        id: spinBox4
+    FloatSpinBox {
+        id: floatSpinBox4
         x: 438
         y: 259
         width: 94
         height: 36
-        from: -2147483648
-        to: 2147483647
         editable: true
-        value: battery.packVoltage
-        onValueChanged: battery.setPackVoltage(value)
+        value: decimalToInt(battery.packVoltage)
+        onValueChanged: battery.setPackVoltage(value/decimalFactor)
+        stepSize: decimalToInt(0.5)
     }
 
     Text {
@@ -190,17 +186,16 @@ Item {
         font.pixelSize: 12
     }
 
-    SpinBox {
-        id: spinBox5
+    FloatSpinBox {
+        id: floatSpinBox5
         x: 538
         y: 259
         width: 94
         height: 36
-        from: -2147483648
-        to: 2147483647
         editable: true
-        value: battery.packSoc
-        onValueChanged: battery.setPackSoc(value)
+        value: decimalToInt(battery.packSoc)
+        onValueChanged: battery.setPackSoc(value/decimalFactor)
+        stepSize: decimalToInt(0.5)
     }
 
     Text {
@@ -211,17 +206,16 @@ Item {
         font.pixelSize: 12
     }
 
-    SpinBox {
-        id: spinBox6
+    FloatSpinBox {
+        id: floatSpinBox6
         x: 638
         y: 259
         width: 94
         height: 36
-        from: -2147483648
-        to: 2147483647
         editable: true
-        value: battery.packAmphours
-        onValueChanged: battery.setPackAmphours(value)
+        value: decimalToInt(battery.packAmphours)
+        onValueChanged: battery.setPackAmphours(value/decimalFactor)
+         stepSize: decimalToInt(0.5)
     }
 
     Text {
@@ -232,17 +226,14 @@ Item {
         font.pixelSize: 12
     }
 
-    SpinBox {
-        id: spinBox7
+    FloatSpinBox {
+        id: floatSpinBox7
         x: 42
         y: 326
         width: 94
         height: 36
-        from: -2147483648
-        to: 2147483647
-        editable: true
-        value: battery.setPackDod
-        onValueChanged: battery.setPackDod(value)
+        value: decimalToInt(battery.setPackDod)
+        onValueChanged: battery.setPackDod(value/decimalFactor)
     }
 
     Text {

--- a/content/CMakeLists.txt
+++ b/content/CMakeLists.txt
@@ -27,4 +27,5 @@ qt6_add_qml_module(content
         QML_FILES ProximitySensorsView.qml
         QML_FILES MbmsView.qml
         QML_FILES TelemetryView.qml
+        QML_FILES FloatSpinBox.qml
 )

--- a/content/DriverControlsView.qml
+++ b/content/DriverControlsView.qml
@@ -174,7 +174,8 @@ Item {
         y: 244
         width: 140
         height: 38
-        to: 4095
+        to: 65535
+        editable: true
         value: driverControls.acceleration
         onValueChanged: driverControls.setAcceleration(value)
     }
@@ -193,7 +194,8 @@ Item {
         y: 308
         width: 140
         height: 38
-        to: 4095
+        to: 65535
+        editable: true
         value: driverControls.regenBraking
         onValueChanged: driverControls.setRegenBraking(value)
     }

--- a/content/FloatSpinBox.qml
+++ b/content/FloatSpinBox.qml
@@ -1,0 +1,28 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+SpinBox {
+    property int decimals: 1
+    readonly property int decimalFactor: Math.pow(10, decimals)
+
+    function decimalToInt(decimal) {
+        return decimal * decimalFactor
+    }
+    from:-2147483648
+    to:2147483647
+    editable:true
+
+    validator: DoubleValidator {
+        decimals: spinBox.decimals
+        notation: DoubleValidator.StandardNotation
+    }
+
+    textFromValue: function(value, locale) {
+        return Number(value / decimalFactor).toLocaleString(locale, 'f',1)
+    }
+
+    valueFromText: function(text, locale) {
+        return Math.round(Number.fromLocaleString(locale, text) * decimalFactor)
+    }
+}
+

--- a/content/KeyMotorView.qml
+++ b/content/KeyMotorView.qml
@@ -45,6 +45,8 @@ Item {
                     y: 0
                     width: 87
                     height: 28
+                    to: 65535
+                    editable: true
                     value: keyMotor.motorSetpoint
                     onValueChanged: keyMotor.setMotorSetpoint(value)
                 }

--- a/content/MbmsView.qml
+++ b/content/MbmsView.qml
@@ -301,7 +301,8 @@ Item {
                 x: 0
                 y: 0
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: mbms.auxillaryBatteryVoltage
                 onValueChanged: mbms.setAuxillaryBatteryVoltage(value)
             }
@@ -311,7 +312,8 @@ Item {
                 x: 161
                 y: 0
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: mbms.motorVoltage
                 onValueChanged: mbms.setMotorVoltage(value)
             }
@@ -321,7 +323,8 @@ Item {
                 x: 323
                 y: 0
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: mbms.arrayVoltage
                 onValueChanged: mbms.setArrayVoltage(value)
             }
@@ -331,7 +334,8 @@ Item {
                 x: 490
                 y: 0
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: mbms.lvVoltage
                 onValueChanged: mbms.setLvVoltage(value)
             }
@@ -341,7 +345,8 @@ Item {
                 x: 662
                 y: 0
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: mbms.chargeVoltage
                 onValueChanged: mbms.setChargeVoltage(value)
             }
@@ -396,7 +401,8 @@ Item {
                 x: 0
                 y: 0
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: mbms.commonCurrent
                 onValueChanged: mbms.setCommonCurrent(value)
             }
@@ -406,7 +412,8 @@ Item {
                 x: 161
                 y: 0
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: mbms.motorCurrent
                 onValueChanged: mbms.setMotorCurrent(value)
             }
@@ -416,7 +423,8 @@ Item {
                 x: 323
                 y: 0
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: mbms.arrayCurrent
                 onValueChanged: mbms.setArrayCurrent(value)
             }
@@ -426,7 +434,8 @@ Item {
                 x: 490
                 y: 0
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: mbms.lvCurrent
                 onValueChanged: mbms.setLvCurrent(value)
             }
@@ -436,7 +445,8 @@ Item {
                 x: 662
                 y: 0
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: mbms.chargeCurrent
                 onValueChanged: mbms.setChargeCurrent(value)
             }

--- a/content/MpptView.qml
+++ b/content/MpptView.qml
@@ -21,6 +21,8 @@ Item {
         y: 33
         width: 90
         height: 35
+        to: 65535
+        editable: true
         value: mppt.arrayVoltage
         onValueChanged: mppt.setArrayVoltage(value)
     }
@@ -39,6 +41,8 @@ Item {
         y: 33
         width: 90
         height: 35
+        to: 65535
+        editable: true
         value: mppt.arrayCurrent
         onValueChanged: mppt.setArrayCurrent(value)
     }
@@ -57,6 +61,8 @@ Item {
         y: 94
         width: 90
         height: 35
+        to: 65535
+        editable: true
         value: mppt.batteryVoltage
         onValueChanged: mppt.setBatteryVoltage(value)
     }
@@ -75,7 +81,8 @@ Item {
         y: 94
         width: 100
         height: 35
-        to: 10000
+        to: 65535
+        editable: true
         value: mppt.temp
         onValueChanged: mppt.setTemp(value)
     }

--- a/content/ProximitySensorsView.qml
+++ b/content/ProximitySensorsView.qml
@@ -20,7 +20,8 @@ Item {
                 x: -102
                 y: -207
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: proximitySensors.proximitySensor1
                 onValueChanged: proximitySensors.setProximitySensor1(value)
             }
@@ -41,7 +42,8 @@ Item {
                 x: -102
                 y: -207
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: proximitySensors.proximitySensor1
                 onValueChanged: proximitySensors.setProximitySensor2(value)
             }
@@ -61,7 +63,8 @@ Item {
                 x: -102
                 y: -207
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: proximitySensors.proximitySensor3
                 onValueChanged: proximitySensors.setProximitySensor3(value)
             }
@@ -81,7 +84,8 @@ Item {
                 x: -102
                 y: -207
                 from: 0
-                to: 255
+                to: 65535
+                editable: true
                 value: proximitySensors.proximitySensor4
                 onValueChanged: proximitySensors.setProximitySensor4(value)
             }

--- a/content/TelemetryView.qml
+++ b/content/TelemetryView.qml
@@ -20,7 +20,8 @@ Item {
                 x: 0
                 y: 0
                 from: 0
-                to: 2200
+                to: 65535
+                editable: true
                 value: telemetry.gpsYear
                 onValueChanged: telemetry.setGpsYear(value)
             }

--- a/src/Battery.cpp
+++ b/src/Battery.cpp
@@ -50,31 +50,31 @@ int Battery::populatedCells() const{
     return populatedCells_;
 }
 
-int Battery::input12V() const{
+float Battery::input12V() const{
     return input12V_;
 }
 
-int Battery::fanVoltage() const{
+float Battery::fanVoltage() const{
     return fanVoltage_;
 }
 
-int Battery::packCurrent() const{
+float Battery::packCurrent() const{
     return packCurrent_;
 }
 
-int Battery::packVoltage() const{
+float Battery::packVoltage() const{
     return packVoltage_;
 }
 
-int Battery::packSoc() const{
+float Battery::packSoc() const{
     return packSoc_;
 }
 
-int Battery::packAmphours() const{
+float Battery::packAmphours() const{
     return packAmphours_;
 }
 
-int Battery::packDod() const{
+float Battery::packDod() const{
     return packDod_;
 }
 
@@ -206,49 +206,49 @@ void Battery::setPopulatedCells(int i){
     updateByteStream();
 }
 
-void Battery::setInput12V(int i){
+void Battery::setInput12V(float i){
     QByteArray in = Util::formatFloat(i);
     byteStream_.replace(5, 4, in);
     input12V_ = i;
     updateByteStream();
 }
 
-void Battery::setFanVoltage(int i){
+void Battery::setFanVoltage(float i){
     QByteArray in = Util::formatFloat(i);
     byteStream_.replace(9, 4, in);
     fanVoltage_ = i;
     updateByteStream();
 }
 
-void Battery::setPackCurrent(int i){
+void Battery::setPackCurrent(float i){
     QByteArray in = Util::formatFloat(i);
     byteStream_.replace(13, 4, in);
     packCurrent_ = i;
     updateByteStream();
 }
 
-void Battery::setPackVoltage(int i){
+void Battery::setPackVoltage(float i){
     QByteArray in = Util::formatFloat(i);
     byteStream_.replace(17, 4, in);
     packCurrent_ = i;
     updateByteStream();
 }
 
-void Battery::setPackSoc(int i){
+void Battery::setPackSoc(float i){
     QByteArray in = Util::formatInt(i, 4);
     byteStream_.replace(21, 4, in);
     packSoc_ = i;
     updateByteStream();
 }
 
-void Battery::setPackAmphours(int i){
+void Battery::setPackAmphours(float i){
     QByteArray in = Util::formatFloat(i);
     byteStream_.replace(25, 4, in);
     packAmphours_ = i;
     updateByteStream();
 }
 
-void Battery::setPackDod(int i){
+void Battery::setPackDod(float i){
     QByteArray in = Util::formatFloat(i);
     byteStream_.replace(29, 4, in);
     packDod_ = i;

--- a/src/Battery.h
+++ b/src/Battery.h
@@ -20,14 +20,14 @@ public:
     Q_PROPERTY(bool isChargingSignal READ isChargingSignal WRITE setIsChargingSignal NOTIFY isChargingSignalChanged FINAL)
 
     Q_PROPERTY(int populatedCells READ populatedCells WRITE setPopulatedCells NOTIFY populatedCellsChanged FINAL)
-    Q_PROPERTY(int input12V READ input12V WRITE setInput12V NOTIFY input12VChanged FINAL)
-    Q_PROPERTY(int fanVoltage READ fanVoltage WRITE setFanVoltage NOTIFY fanVoltageChanged FINAL)
-    Q_PROPERTY(int packCurrent READ packCurrent WRITE setPackCurrent NOTIFY packCurrentChanged FINAL)
-    Q_PROPERTY(int packVoltage READ packVoltage WRITE setPackVoltage NOTIFY packVoltageChanged FINAL)
-    Q_PROPERTY(int packSoc READ packSoc WRITE setPackSoc NOTIFY packSocChanged FINAL)
-    Q_PROPERTY(int packAmphours READ packAmphours WRITE setPackAmphours NOTIFY packAmphoursChanged FINAL)
+    Q_PROPERTY(float input12V READ input12V WRITE setInput12V NOTIFY input12VChanged FINAL)
+    Q_PROPERTY(float fanVoltage READ fanVoltage WRITE setFanVoltage NOTIFY fanVoltageChanged FINAL)
+    Q_PROPERTY(float packCurrent READ packCurrent WRITE setPackCurrent NOTIFY packCurrentChanged FINAL)
+    Q_PROPERTY(float packVoltage READ packVoltage WRITE setPackVoltage NOTIFY packVoltageChanged FINAL)
+    Q_PROPERTY(float packSoc READ packSoc WRITE setPackSoc NOTIFY packSocChanged FINAL)
+    Q_PROPERTY(float packAmphours READ packAmphours WRITE setPackAmphours NOTIFY packAmphoursChanged FINAL)
 
-    Q_PROPERTY(int packDod READ packDod WRITE setPackDod NOTIFY packDodChanged FINAL)
+    Q_PROPERTY(float packDod READ packDod WRITE setPackDod NOTIFY packDodChanged FINAL)
     Q_PROPERTY(int highTemp READ highTemp WRITE setHighTemp NOTIFY highTempChanged FINAL)
     Q_PROPERTY(int highThermistorId READ highThermistorId WRITE setHighThermistorId NOTIFY highThermistorIdChanged FINAL)
     Q_PROPERTY(int lowTemp READ lowTemp WRITE setLowTemp NOTIFY lowTempChanged FINAL)
@@ -57,14 +57,14 @@ public:
     bool isChargingSignal() const;
 
     int populatedCells() const;
-    int input12V() const;
-    int fanVoltage() const;
-    int packCurrent() const;
-    int packVoltage() const;
-    int packSoc() const;
-    int packAmphours() const;
+    float input12V() const;
+    float fanVoltage() const;
+    float packCurrent() const;
+    float packVoltage() const;
+    float packSoc() const;
+    float packAmphours() const;
 
-    int packDod() const;
+    float packDod() const;
     int highTemp() const;
     int highThermistorId() const;
     int lowTemp() const;
@@ -97,14 +97,14 @@ public slots:
     void setIsChargingSignal(bool on);
 
     void setPopulatedCells(int i);
-    void setInput12V(int i);
-    void setFanVoltage(int i);
-    void setPackCurrent(int i);
-    void setPackVoltage(int i);
-    void setPackSoc(int i);
-    void setPackAmphours(int i);
+    void setInput12V(float i);
+    void setFanVoltage(float i);
+    void setPackCurrent(float i);
+    void setPackVoltage(float i);
+    void setPackSoc(float i);
+    void setPackAmphours(float i);
 
-    void setPackDod(int i);
+    void setPackDod(float i);
     void setHighTemp(int i);
     void setHighThermistorId(int i);
     void setLowTemp(int i);
@@ -132,14 +132,14 @@ signals:
     void isChargingSignalChanged(bool on);
 
     void populatedCellsChanged(int i);
-    void input12VChanged(int i);
-    void fanVoltageChanged(int i);
-    void packCurrentChanged(int i);
-    void packVoltageChanged(int i);
-    void packSocChanged(int i);
-    void packAmphoursChanged(int i);
+    void input12VChanged(float i);
+    void fanVoltageChanged(float i);
+    void packCurrentChanged(float i);
+    void packVoltageChanged(float i);
+    void packSocChanged(float i);
+    void packAmphoursChanged(float i);
 
-    void packDodChanged(int i);
+    void packDodChanged(float i);
     void highTempChanged(int i);
     void highThermistorIdChanged(int i);
     void lowTempChanged(int i);
@@ -170,14 +170,14 @@ private:
     bool isChargingSignal_ = false;
 
     int populatedCells_ = 0;
-    int input12V_ = 0;
-    int fanVoltage_ = 0;
-    int packCurrent_ = 0;
-    int packVoltage_ = 0;
-    int packSoc_ = 0;
-    int packAmphours_ = 0;
+    float input12V_ = 0.0;
+    float fanVoltage_ = 0.0;
+    float packCurrent_ = 0;
+    float packVoltage_ = 0;
+    float packSoc_ = 0;
+    float packAmphours_ = 0;
 
-    int packDod_ = 0;
+    float packDod_ = 0;
     int highTemp_ = 0;
     int highThermistorId_ = 0;
     int lowTemp_ = 0;


### PR DESCRIPTION
 ### Changes:
- All SpinBox can have valued typed in.
- Created a FloatSpinBox that is able to handle decimal values
- Changed range of values able to be accepted into SpinBox based on variable type:
   - Float range is set to integers minimum and maximum due to SpinBox only accepting Integer.
   - uchar range is 0 - 255.
   -  uint range is 0 - 65535
- Changed header and cpp file for Battery packet to have proper variables set to float (previously were int).

### Tested:
- Tested sending BatteryView from tester tool to Hermes. Was able to properly receive decimal values.

